### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/peacefair_energy/sensor.py
+++ b/custom_components/peacefair_energy/sensor.py
@@ -1,3 +1,6 @@
+from homeassistant.components.sensor import (
+    SensorDeviceClass
+)
 from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfElectricPotential,
@@ -5,15 +8,6 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfEnergy,
     UnitOfFrequency
-)
-from homeassistant.components.sensor import (
-    DOMAIN as SENSOR_PLATFORM,
-    RestoreSensor,
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorExtraStoredData,
-    SensorStateClass,
 )
 from .const import (
     DOMAIN,

--- a/custom_components/peacefair_energy/sensor.py
+++ b/custom_components/peacefair_energy/sensor.py
@@ -1,22 +1,24 @@
 from homeassistant.const import (
     STATE_UNKNOWN,
-    DEVICE_CLASS_VOLTAGE,
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER_FACTOR,
-    ELECTRIC_POTENTIAL_VOLT,
-    ELECTRIC_CURRENT_AMPERE,
-    POWER_WATT,
-    ENERGY_KILO_WATT_HOUR,
-    FREQUENCY_HERTZ
+    UnitOfElectricPotential,
+    UnitOfElectricCurrent,
+    UnitOfPower,
+    UnitOfEnergy,
+    UnitOfFrequency
 )
-
+from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_PLATFORM,
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorExtraStoredData,
+    SensorStateClass,
+)
 from .const import (
     DOMAIN,
     COORDINATOR,
     ENERGY_SENSOR,
-    DEVICE_CLASS_FREQUENCY,
     VERSION,
     STORAGE_PATH
 )
@@ -34,33 +36,33 @@ _LOGGER = logging.getLogger(__name__)
 
 
 HPG_SENSORS = {
-    DEVICE_CLASS_VOLTAGE: {
+    SensorDeviceClass.VOLTAGE: {
         "name": "Voltage",
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "state_class": "measurement"
     },
-    DEVICE_CLASS_CURRENT: {
+    SensorDeviceClass.CURRENT: {
         "name": "Current",
-        "unit": ELECTRIC_CURRENT_AMPERE,
+        "unit": UnitOfElectricCurrent.AMPERE,
         "state_class": "measurement"
     },
-    DEVICE_CLASS_POWER: {
+    SensorDeviceClass.POWER: {
         "name": "Power",
-        "unit": POWER_WATT,
+        "unit": UnitOfPower.WATT,
         "state_class": "measurement"
     },
-    DEVICE_CLASS_ENERGY: {
+    SensorDeviceClass.ENERGY: {
         "name": "Energy",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        "unit": UnitOfEnergy.KILO_WATT_HOUR,
         "state_class": "total_increasing"
     },
-    DEVICE_CLASS_POWER_FACTOR: {
+    SensorDeviceClass.POWER_FACTOR: {
         "name": "Power Factor",
         "state_class": "measurement"
     },
-    DEVICE_CLASS_FREQUENCY: {
+    SensorDeviceClass.FREQUENCY: {
         "name": "Power Frequency",
-        "unit": FREQUENCY_HERTZ,
+        "unit": UnitOfFrequency.HERTZ,
         "icon": "hass:current-ac",
         "state_class": "measurement"
     },
@@ -107,7 +109,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if len(json_data) > 0:
             state = json_data[history_type]["history_state"]
         _LOGGER.debug(f"Load {history_type} history data {state}")
-        h_sensor = HPGHistorySensor(history_type, DEVICE_CLASS_ENERGY, ident, state)
+        h_sensor = HPGHistorySensor(history_type, SensorDeviceClass.ENERGY, ident, state)
         sensors.append(h_sensor)
         state = STATE_UNKNOWN
         last_state = STATE_UNKNOWN
@@ -116,7 +118,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             state = json_data[history_type]["real_state"]
             last_state = json_data["last_state"]
             last_time = json_data["last_time"]
-        r_sensor = HPGRealSensor(history_type, DEVICE_CLASS_ENERGY, ident, h_sensor, state, last_state, last_time)
+        r_sensor = HPGRealSensor(history_type, SensorDeviceClass.ENERGY, ident, h_sensor, state, last_state, last_time)
         sensors.append(r_sensor)
         updates[history_type] = r_sensor.update_state
     json_data = load_json(reset_file, default={})
@@ -251,7 +253,7 @@ class HPGSensor(CoordinatorEntity, HPGBaseSensor):
         self._last_reset = datetime.datetime.fromtimestamp(last_reset)
         self._record_file = f"{STORAGE_PATH}/{entry_id}_state.json"
         self._reset_file = f"{STORAGE_PATH}/{entry_id}_reset.json"
-        if self._sensor_type == DEVICE_CLASS_ENERGY:
+        if self._sensor_type == SensorDeviceClass.ENERGY:
             coordinator.set_update(self.update_state)
 
     @property
@@ -275,12 +277,12 @@ class HPGSensor(CoordinatorEntity, HPGBaseSensor):
 
     @property
     def last_reset(self):
-        return self._last_reset if self._sensor_type == DEVICE_CLASS_ENERGY else None
+        return self._last_reset if self._sensor_type == SensorDeviceClass.ENERGY else None
 
     @final
     @property
     def state_attributes(self):
-        return {ATTR_LAST_RESET: self.last_reset.isoformat()} if self._sensor_type == DEVICE_CLASS_ENERGY else {}
+        return {ATTR_LAST_RESET: self.last_reset.isoformat()} if self._sensor_type == SensorDeviceClass.ENERGY else {}
 
     def reset(self):
         self._last_reset = datetime.datetime.now()


### PR DESCRIPTION
ELECTRIC_CURRENT_AMPERE was used from peacefair_energy, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfElectricCurrent.AMPERE instead.........................